### PR TITLE
fix: enable TypeScript noImplicitAny strict mode

### DIFF
--- a/bff/tsconfig.json
+++ b/bff/tsconfig.json
@@ -31,7 +31,7 @@
     "outDir": "dist",
     "sourceMap": true,
     "declaration": true,
-    "noImplicitAny": false,
+    "noImplicitAny": true,
     "strictNullChecks": true,
     "strictFunctionTypes": true,
     "strictBindCallApply": true,


### PR DESCRIPTION
## Summary

- Enable `noImplicitAny: true` in `bff/tsconfig.json`
- Improves type safety by catching implicit `any` types at compile time

## Background

The 11 pre-existing TypeScript errors discovered during implementation were caused by a stale `db` package build (the `dist/models/User.d.ts` was out of sync with the source). These errors were not related to `noImplicitAny` and are resolved by rebuilding the db package.

## Test Plan

- [x] TypeScript compilation passes (`tsc --noEmit`)
- [x] All 318 BFF tests pass
- [x] All 162 DB tests pass

## Note for CI

If CI fails with type errors about missing properties on `User` type, run:
```bash
cd db && npm run build
```

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)